### PR TITLE
first approach to render performance stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^4.5.1",
     "html-webpack-plugin": "^3.2.0",
+    "stats.js": "^0.17.0",
     "webpack": "^4.10.2",
     "webpack-cli": "^3.0.2",
     "webpack-dev-server": "^3.1.4",

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -25,6 +25,9 @@ const DISPLAY_SCENE_TITLE = true
 // scene looks like
 const FAKE_LOADER_ACTIVE = false
 
+// display stats
+const RUNNING_STATS = true
+
 export default {
   WIDTH: 800 * SCALE,
   HEIGHT: 600 * SCALE,
@@ -34,5 +37,6 @@ export default {
   TIME_SPLASH,
   TIME_MADE_WITH,
   DISPLAY_SCENE_TITLE,
+  RUNNING_STATS,
   KEY: 'value'
 }

--- a/src/index.js
+++ b/src/index.js
@@ -46,3 +46,4 @@ getDataManager()
 document.getElementById('game').focus()
 
 window.focus()
+

--- a/src/scenes/game/HUDGame.js
+++ b/src/scenes/game/HUDGame.js
@@ -38,5 +38,8 @@ export default class HUDGameScene extends Scene {
       this.lapsText.setText(this.getText('laps', [data]))
     }
   }
+  
+  // dont  call the super update function....
+  update() {}
 
 }

--- a/src/scenes/game/baseGame.js
+++ b/src/scenes/game/baseGame.js
@@ -27,6 +27,7 @@ export default class BaseGameScene extends Scene {
   }
 
   update () {
+    super.update()
     this.logo.rotation += this.rotationRatio
     if(this.logo.rotation>(Math.PI-0.1)) {
       this.laps++
@@ -39,5 +40,13 @@ export default class BaseGameScene extends Scene {
       this.registry.set('laps', this.laps)
       this.changeToScene('baseGameScene', {color: ~~(Math.random()*0xffffff), rotation: -this.rotationRatio})
     }
+
+  }
+
+  /**
+    only for performance
+  */
+  updateCustomStats() {
+    this.customTrackingStats.custom = this.laps
   }
 }

--- a/src/scenes/scene.js
+++ b/src/scenes/scene.js
@@ -3,7 +3,10 @@ import fonts from '../config/fonts'
 import getSceneManager from '../managers/sceneManager'
 import getTranslator from '../managers/translatorManager'
 
+import stats from '../utils/performance'
+
 import Button from '../gameObjects/button'
+
 
 export default class Scene extends Phaser.Scene {
   constructor (params) {
@@ -12,6 +15,10 @@ export default class Scene extends Phaser.Scene {
     this.fonts = fonts
 
     this.defaultBitmapStyle = fonts.BM_keney
+
+    if (constants.RUNNING_STATS) {
+      this.customTrackingStats = {}
+    }
   }
 
   preload () {
@@ -86,5 +93,16 @@ export default class Scene extends Phaser.Scene {
     }
     return this.translator.translate(val)
   }
+
+
+  update() {
+    if (constants.RUNNING_STATS) {
+      this.updateCustomStats()
+      stats.end(this.customTrackingStats)
+      stats.begin()
+    }
+  }
+
+  updateCustomStats() {}
 
 }

--- a/src/utils/performance.js
+++ b/src/utils/performance.js
@@ -1,0 +1,52 @@
+import constants from '../config/constants'
+import Stats from 'stats.js'
+
+let loadStats = () => {
+  let fps = new Stats()
+  let processing = new Stats()
+  let memory = new Stats()
+  
+  // add your custom panel right here
+  let customStats = new Stats()
+  var customPanel = customStats.addPanel(
+    new Stats.Panel('custom', '#ff8', '#221')
+  )
+
+  fps.showPanel(0)
+  processing.showPanel(1)
+  memory.showPanel(2)
+  customStats.showPanel(3)
+  
+  let allPanels = [fps, processing, memory, customStats]
+  allPanels.forEach((panel, index) => {
+    panel.domElement.style.position = 'absolute'
+    panel.domElement.style.left = 'inherit'
+    panel.domElement.style.right = `${index*100}px`
+    panel.domElement.style.top = '0px'
+    document.body.appendChild(panel.domElement)
+  })
+ 
+  return {
+    begin: () => {
+      fps.begin()
+      processing.begin()
+      memory.begin()
+      customStats.begin()
+    },
+    end: (values) => {
+      fps.end()
+      processing.end()
+      memory.end()
+      customStats.end()
+      
+      if(values.hasOwnProperty('custom')) {
+        customPanel.update(values.custom, 2)
+      }
+    }
+  }
+}
+
+let stats = {}
+if (constants.RUNNING_STATS) stats = loadStats()
+
+export default stats


### PR DESCRIPTION
use `constants.RUNNING_STATS` to turn on/off the stats plugin.
By default, Base Scene tracks fps/ms/memory in each `update` call.